### PR TITLE
When refresh token fails, user is redirected to login page

### DIFF
--- a/projects/ngx-wso2-authentication/package.json
+++ b/projects/ngx-wso2-authentication/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-wso2-authentication",
-  "version": "0.0.4",
+  "version": "0.0.7",
   "peerDependencies": {
     "@angular/common": "^7.2.0",
     "@angular/core": "^7.2.0"

--- a/projects/ngx-wso2-authentication/src/index.ts
+++ b/projects/ngx-wso2-authentication/src/index.ts
@@ -27,6 +27,10 @@ export * from './lib/guard/authentication.guard';
 // Directivers
 export * from './lib/directive/hasRole.directive';
 
+// Models
+export * from './lib/model/token.model';
+export * from './lib/model/user.model';
+
 export interface NgxWso2Config {
   authorizeUri: string;
   clientId: string;

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -4,7 +4,9 @@ import { LoginComponent, NgxWso2AuthenticationGuard, AccessDeniedComponent } fro
 import { HomeComponent } from './components/home/home.component';
 
 const routes: Routes = [
-  { path: '', component: HomeComponent, canActivate: [NgxWso2AuthenticationGuard], data: { expectedRole: 'Users_WTS2K_SLA_POPMUSYSACE' } },
+  //{ path: '', component: HomeComponent, canActivate: [NgxWso2AuthenticationGuard], data: { expectedRole: '' } },
+  { path: '', component: HomeComponent, canActivate: [NgxWso2AuthenticationGuard]  },
+
   { path: 'login', component: LoginComponent },
   { path: 'access-denied', component: AccessDeniedComponent }
 ];


### PR DESCRIPTION
When refresh token fails, user is redirected to login page. Removed role from app-routing.module. Attempts to renew token are now 3 before going to login page.